### PR TITLE
Fix workflow dependencies to verify-releaser job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
 
   # Post version bump information comment on PR when labeled
   release-preview-comment:
+    needs: [verify-releaser]
     if: github.event.action == 'labeled'
     permissions:
       pull-requests: write
@@ -31,6 +32,7 @@ jobs:
 
   # First check if a release is needed
   release-check:
+    needs: [verify-releaser]
     if: github.event.action != 'labeled'
     permissions:
       contents: write # Required for GitHub's generate-release-note API (notes are only displayed in job summary, not written to any file)
@@ -39,7 +41,7 @@ jobs:
 
   # Environment protection job
   release-approval:
-    needs: [release-check]
+    needs: [verify-releaser, release-check]
     if: github.event.action != 'labeled' && needs.release-check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     environment: release
@@ -52,7 +54,7 @@ jobs:
 
   # Use the reusable trusted tag workflow for releases if approved
   release:
-    needs: [release-check, release-approval]
+    needs: [verify-releaser, release-check, release-approval]
     if: github.event.action != 'labeled' && needs.release-check.outputs.skip != 'true'
     concurrency:
       group: "release"


### PR DESCRIPTION
## Summary
- Fixed release workflow job dependencies to ensure verify-releaser runs before all other jobs
- Added proper dependency chain for security verification

## Changes
- `release-preview-comment` now depends on `verify-releaser`
- `release-check` now depends on `verify-releaser`  
- `release-approval` now depends on `verify-releaser` and `release-check`
- `release` now depends on `verify-releaser`, `release-check`, and `release-approval`

## Test plan
- [x] Verified workflow syntax is correct
- [x] Ensured dependency order makes sense for security

This ensures the trusted tag verification completes successfully before any release operations begin.

🤖 Generated with [Claude Code](https://claude.ai/code)