### PR TITLE
Prevent duplicate attestations by checking install script changes

### DIFF
--- a/.config/binstaller.yml
+++ b/.config/binstaller.yml
@@ -1,4 +1,5 @@
 # Configuration for binstaller install script generation
+# Updated to test duplicate attestation prevention
 schema: v1
 name: binst
 repo: binary-install/binstaller

--- a/.github/workflows/generate-installer.yml
+++ b/.github/workflows/generate-installer.yml
@@ -40,7 +40,21 @@ jobs:
           ./binst gen -o install.sh
           echo "✅ Install script generated successfully"
 
+      - name: Check for changes in install script
+        id: check_changes
+        run: |
+          echo "🔍 Checking if install script has changes..."
+          
+          if git diff --quiet install.sh; then
+            echo "ℹ️ No changes detected in install.sh"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "✅ Changes detected in install.sh"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Test generated script
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           echo "🧪 Testing generated install script..."
           
@@ -57,16 +71,19 @@ jobs:
           echo "✅ Script execution test passed"
 
       - name: Attest install script
+        if: steps.check_changes.outputs.has_changes == 'true'
         uses: actions/attest-build-provenance@v1
         id: attest
         with:
           subject-path: install.sh
 
       - name: Get current date
+        if: steps.check_changes.outputs.has_changes == 'true'
         id: date
         run: echo "date=$(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
 
       - name: Create PR with attested script
+        if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -119,6 +136,7 @@ jobs:
             attestation
 
       - name: Output summary
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           echo "## 🎉 Workflow Summary"
           echo ""
@@ -133,3 +151,13 @@ jobs:
           echo ""
           echo "### Verification Command"
           echo "gh attestation verify install.sh --repo ${{ github.repository }}"
+
+      - name: Report no changes
+        if: steps.check_changes.outputs.has_changes == 'false'
+        run: |
+          echo "## ℹ️ No Changes Detected" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The generated install script is identical to the existing one." >> $GITHUB_STEP_SUMMARY
+          echo "No new attestation was created and no PR will be generated." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This prevents duplicate attestations for the same content." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

This PR improves the generate-installer workflow to prevent unnecessary duplicate attestations by checking if the install script has actually changed before creating attestation.

## Problem

Currently, the workflow creates a new attestation every time it runs, even when the generated install script is identical to the existing one. This leads to:
- Multiple attestations for the same content
- Unnecessary resource usage
- Confusion about which attestation to use

## Solution

### 🔍 Diff Check
- Add `Check for changes in install script` step using `git diff`
- Only proceed with attestation if actual changes are detected

### 🎯 Conditional Execution
Make the following steps conditional on `has_changes == 'true'`:
- Test generated script
- Attest install script
- Get current date
- Create PR with attested script
- Output summary

### 📝 Clear Feedback
- Add `Report no changes` step when no changes are detected
- Provide clear explanation in GitHub Actions summary
- Users understand why no PR was created

## Benefits

- ✅ **Prevents duplicate attestations**: Only creates attestation for actual changes
- ✅ **Saves resources**: Skips unnecessary steps when content is unchanged
- ✅ **Clear communication**: Users understand workflow behavior
- ✅ **Maintains security**: Still generates attestation for real updates

## Testing

The workflow maintains all existing functionality while adding the smart diff check. When content changes, it behaves exactly as before. When content is unchanged, it provides clear feedback and skips unnecessary operations.

🤖 Generated with [Claude Code](https://claude.ai/code)