### PR TITLE
Fix diff check logic using git add approach

### DIFF
--- a/.config/binstaller.yml
+++ b/.config/binstaller.yml
@@ -1,4 +1,5 @@
 # Configuration for binstaller install script generation
+# Updated to test the fixed diff check logic with git add
 schema: v1
 name: binst
 repo: binary-install/binstaller

--- a/.github/workflows/generate-installer.yml
+++ b/.github/workflows/generate-installer.yml
@@ -45,7 +45,11 @@ jobs:
         run: |
           echo "🔍 Checking if install script has changes..."
           
-          if git diff --quiet install.sh; then
+          # Add the file to git staging area
+          git add install.sh
+          
+          # Check if there are any staged changes
+          if git diff --cached --quiet; then
             echo "ℹ️ No changes detected in install.sh"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Problem

The previous implementation from PR #30 had a critical flaw: `git diff --quiet install.sh` doesn't work for newly generated files because git diff doesn't detect untracked files.

## Solution

### 🎯 Simplified Approach
Use Git's staging area to detect changes:

```bash
# Add file to staging area
git add install.sh

# Check for staged changes
if git diff --cached --quiet; then
  echo "No changes"
else
  echo "Changes detected"
fi
```

### ✅ Benefits
- **Works for all cases**: New files, modified files, unchanged files
- **No backup files**: Cleaner and simpler
- **Git-native**: Uses Git's built-in change detection
- **Reliable**: Consistent with how peter-evans/create-pull-request works

## Testing

This PR includes a change to `.config/binstaller.yml` that will trigger the workflow when merged, allowing us to test:
1. First run: Creates install.sh (new file) → should detect changes
2. Second run: No changes to install.sh → should skip attestation

## Changes
- Simplified diff check logic in generate-installer.yml
- Added test trigger in .config/binstaller.yml

🤖 Generated with [Claude Code](https://claude.ai/code)