### PR TITLE
Unify config file detection logic across subcommands

### DIFF
--- a/cmd/binst/embed_checksums.go
+++ b/cmd/binst/embed_checksums.go
@@ -34,26 +34,14 @@ This command supports three modes of operation:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info("Running embed-checksums command...")
 
-		// Determine config file path
-		cfgFile := configFile // Use the global flag value
-		if cfgFile == "" {
-			// Default detection logic if global flag is not set
-			defaultPath := ".binstaller.yml"
-			if _, err := os.Stat(defaultPath); err == nil {
-				cfgFile = defaultPath
-				log.Infof("Using default config file: %s", cfgFile)
-			} else {
-				// Try .binstaller.yaml as fallback
-				defaultPathYaml := ".binstaller.yaml"
-				if _, errYaml := os.Stat(defaultPathYaml); errYaml == nil {
-					cfgFile = defaultPathYaml
-					log.Infof("Using default config file: %s", cfgFile)
-				} else {
-					err := fmt.Errorf("config file not specified via --config and default (.binstaller.yml or .binstaller.yaml) not found")
-					log.WithError(err).Error("Config file detection failed")
-					return err
-				}
-			}
+		// Determine config file path using common logic
+		cfgFile, err := resolveConfigFile(configFile)
+		if err != nil {
+			log.WithError(err).Error("Config file detection failed")
+			return err
+		}
+		if configFile == "" {
+			log.Infof("Using default config file: %s", cfgFile)
 		}
 		log.Debugf("Using config file: %s", cfgFile)
 

--- a/cmd/binst/gen.go
+++ b/cmd/binst/gen.go
@@ -29,31 +29,20 @@ generates a POSIX-compatible shell installer script.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info("Running gen command...")
 
-		// Determine config file path
-		cfgFile := configFile // Use the global flag value
-		if cfgFile == "" {
-			// Default detection logic if global flag is not set
-			if _, err := os.Stat(DefaultConfigPathYML); err == nil {
-				cfgFile = DefaultConfigPathYML
-				log.Infof("Using default config file: %s", cfgFile)
-			} else {
-				// Try .config/binstaller.yaml as fallback
-				if _, errYaml := os.Stat(DefaultConfigPathYAML); errYaml == nil {
-					cfgFile = DefaultConfigPathYAML
-					log.Infof("Using default config file: %s", cfgFile)
-				} else {
-					err := fmt.Errorf("config file not specified via --config and default (%s or %s) not found", DefaultConfigPathYML, DefaultConfigPathYAML)
-					log.WithError(err).Error("Config file detection failed")
-					return err
-				}
-			}
+		// Determine config file path using common logic
+		cfgFile, err := resolveConfigFile(configFile)
+		if err != nil {
+			log.WithError(err).Error("Config file detection failed")
+			return err
+		}
+		if configFile == "" {
+			log.Infof("Using default config file: %s", cfgFile)
 		}
 		log.Debugf("Using config file: %s", cfgFile)
 
 		// Read the InstallSpec YAML file
 		log.Debugf("Reading InstallSpec from: %s", cfgFile)
 		var yamlData []byte
-		var err error
 		if cfgFile == "-" {
 			log.Debug("Reading install spec from stdin")
 			yamlData, err = io.ReadAll(os.Stdin)

--- a/cmd/binst/init.go
+++ b/cmd/binst/init.go
@@ -28,7 +28,7 @@ var (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Generate an InstallSpec config file from various sources",
-	Long: `Initializes a binstaller configuration file (.binstaller.yml) by detecting
+	Long: `Initializes a binstaller configuration file (.config/binstaller.yml) by detecting
 settings from a source like a GoReleaser config file or a GitHub repository.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Running init command...")

--- a/cmd/binst/main.go
+++ b/cmd/binst/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
@@ -13,6 +14,25 @@ const (
 	DefaultConfigPathYML  = ".config/binstaller.yml"
 	DefaultConfigPathYAML = ".config/binstaller.yaml"
 )
+
+// resolveConfigFile determines the config file path to use.
+// If configFile is not empty, it returns configFile.
+// Otherwise, it tries to find default config files in order.
+func resolveConfigFile(configFile string) (string, error) {
+	if configFile != "" {
+		return configFile, nil
+	}
+
+	// Try default paths in order
+	candidates := []string{DefaultConfigPathYML, DefaultConfigPathYAML}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("config file not specified via --config and default (%s or %s) not found", DefaultConfigPathYML, DefaultConfigPathYAML)
+}
 
 var (
 	// Version and Commit are set during build


### PR DESCRIPTION
## Summary
- Consolidates config file detection into a common `resolveConfigFile` function in `main.go`
- Updates all subcommands to use `.config/` directory defaults consistently
- Fixes `embed-checksums` command to use `.config/binstaller.yml` instead of `.binstaller.yml` in current directory
- Updates help text in `init` command to reflect correct default path

## Test plan
- [x] Build succeeds without errors
- [x] All subcommands now use consistent config file detection logic
- [x] Help text displays correct default paths
- [x] Existing tests continue to pass (except unrelated GoReleaser test)

🤖 Generated with [Claude Code](https://claude.ai/code)