### PR TITLE
Fix help text to show actual default bindir value

### DIFF
--- a/.config/binstaller.yml
+++ b/.config/binstaller.yml
@@ -1,4 +1,3 @@
-# Configuration for binstaller install script generation
 schema: v1
 name: binst
 repo: binary-install/binstaller

--- a/internal/shell/template.tmpl.sh
+++ b/internal/shell/template.tmpl.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d]{{- if not .TargetVersion }} [tag]{{- end }}
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to {{ .DefaultBinDir }}
   -d turns on debug logging
   {{- if .TargetVersion }}
    This installer is configured for {{ .TargetVersion }} only.

--- a/testdata/ast-grep.install.sh
+++ b/testdata/ast-grep.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/ast-grep/ast-grep/releases

--- a/testdata/bat.install.sh
+++ b/testdata/bat.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/sharkdp/bat/releases

--- a/testdata/bump.install.sh
+++ b/testdata/bump.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/haya14busa/bump/releases

--- a/testdata/cargo-deny.install.sh
+++ b/testdata/cargo-deny.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/EmbarkStudios/cargo-deny/releases

--- a/testdata/cnappgoat.install.sh
+++ b/testdata/cnappgoat.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/tenable/cnappgoat/releases

--- a/testdata/dockle.install.sh
+++ b/testdata/dockle.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/goodwithtech/dockle/releases

--- a/testdata/dotter.install.sh
+++ b/testdata/dotter.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/SuperCuber/dotter/releases

--- a/testdata/dua-cli.install.sh
+++ b/testdata/dua-cli.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/Byron/dua-cli/releases

--- a/testdata/fzf.install.sh
+++ b/testdata/fzf.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/junegunn/fzf/releases

--- a/testdata/gh-setup.install.sh
+++ b/testdata/gh-setup.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/k1LoW/gh-setup/releases

--- a/testdata/gh.install.sh
+++ b/testdata/gh.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/cli/cli/releases

--- a/testdata/ghq.install.sh
+++ b/testdata/ghq.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/x-motemen/ghq/releases

--- a/testdata/git-bump.install.sh
+++ b/testdata/git-bump.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/babarot/git-bump/releases

--- a/testdata/golangci-lint.install.sh
+++ b/testdata/golangci-lint.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/golangci/golangci-lint/releases

--- a/testdata/goreleaser.install.sh
+++ b/testdata/goreleaser.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/goreleaser/goreleaser/releases

--- a/testdata/gorss.install.sh
+++ b/testdata/gorss.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/Lallassu/gorss/releases

--- a/testdata/gum.install.sh
+++ b/testdata/gum.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/charmbracelet/gum/releases

--- a/testdata/hugo.install.sh
+++ b/testdata/hugo.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/gohugoio/hugo/releases

--- a/testdata/jq.install.sh
+++ b/testdata/jq.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/jqlang/jq/releases

--- a/testdata/kauthproxy.install.sh
+++ b/testdata/kauthproxy.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/int128/kauthproxy/releases

--- a/testdata/micro.install.sh
+++ b/testdata/micro.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/zyedidia/micro/releases

--- a/testdata/reviewdog.install.sh
+++ b/testdata/reviewdog.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/reviewdog/reviewdog/releases

--- a/testdata/ripgrep.install.sh
+++ b/testdata/ripgrep.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/BurntSushi/ripgrep/releases

--- a/testdata/rush.install.sh
+++ b/testdata/rush.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/shenwei356/rush/releases

--- a/testdata/shellcheck.install.sh
+++ b/testdata/shellcheck.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/koalaman/shellcheck/releases

--- a/testdata/sigspy.install.sh
+++ b/testdata/sigspy.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/actionutils/sigspy/releases

--- a/testdata/slsa-verifier.install.sh
+++ b/testdata/slsa-verifier.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/slsa-framework/slsa-verifier/releases

--- a/testdata/treesitter.install.sh
+++ b/testdata/treesitter.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/tree-sitter/tree-sitter/releases

--- a/testdata/ubi.install.sh
+++ b/testdata/ubi.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/houseabsolute/ubi/releases

--- a/testdata/xh.install.sh
+++ b/testdata/xh.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/ducaale/xh/releases

--- a/testdata/xo.install.sh
+++ b/testdata/xo.install.sh
@@ -8,7 +8,7 @@ usage() {
 $this: download ${NAME} from ${REPO}
 
 Usage: $this [-b bindir] [-d] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to ${BINSTALLER_BIN:-${HOME}/.local/bin}
   -d turns on debug logging
    [tag] is a tag from
    https://github.com/xo/xo/releases


### PR DESCRIPTION
## Summary
- Fixed the help text in generated installer scripts to show the actual default binary directory value from the config
- Previously hardcoded to show "./bin", now uses the template variable `{{ .DefaultBinDir }}`

## Test plan
- [x] Updated template file `internal/shell/template.tmpl.sh`
- [x] All test installer scripts were regenerated with the fix
- [x] Run `make test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)