### PR TITLE
chore: remove unused --all-platforms flag from embed-checksums

### DIFF
--- a/cmd/embed_checksums.go
+++ b/cmd/embed_checksums.go
@@ -15,11 +15,10 @@ import (
 
 var (
 	// Flags for embed-checksums command
-	embedVersion      string
-	embedOutput       string
-	embedMode         string
-	embedFile         string
-	embedAllPlatforms bool
+	embedVersion string
+	embedOutput  string
+	embedMode    string
+	embedFile    string
 )
 
 // EmbedChecksumsCommand represents the embed-checksums command
@@ -93,7 +92,6 @@ This command supports three modes of operation:
 			Spec:         &installSpec,
 			SpecAST:      ast,
 			ChecksumFile: embedFile,
-			AllPlatforms: embedAllPlatforms,
 		}
 
 		// Embed the checksums
@@ -137,7 +135,6 @@ func init() {
 	EmbedChecksumsCommand.Flags().StringVarP(&embedOutput, "output", "o", "", "Output path for the updated InstallSpec (default: overwrite input file)")
 	EmbedChecksumsCommand.Flags().StringVarP(&embedMode, "mode", "m", "download", "Checksums acquisition mode (download, checksum-file, calculate)")
 	EmbedChecksumsCommand.Flags().StringVarP(&embedFile, "file", "f", "", "Path to checksum file (required for checksum-file mode)")
-	EmbedChecksumsCommand.Flags().BoolVar(&embedAllPlatforms, "all-platforms", false, "Generate checksums for all supported platforms (for calculate mode)")
 
 	// Mark required flags
 	EmbedChecksumsCommand.MarkFlagRequired("mode")

--- a/pkg/checksums/checksums.go
+++ b/pkg/checksums/checksums.go
@@ -41,7 +41,6 @@ type Embedder struct {
 	Spec         *spec.InstallSpec
 	SpecAST      *ast.File
 	ChecksumFile string
-	AllPlatforms bool
 }
 
 // Embed performs the checksum embedding process and returns the updated spec


### PR DESCRIPTION
## Summary
- Removed the unused `--all-platforms` flag from the `embed-checksums` command
- Cleaned up related code in both command definition and Embedder struct

## Details
The `--all-platforms` flag was defined but never actually used in the implementation. The actual behavior for platform selection in calculate mode is:
- If `supported_platforms` is defined in the config file, those platforms are used
- Otherwise, a default set of common platforms is used (linux/darwin/windows × amd64/arm64/386)

This change removes the confusion caused by having a non-functional flag in the CLI.

## Test plan
- [x] All existing tests pass
- [x] `binst embed-checksums --help` no longer shows the --all-platforms flag
- [x] embed-checksums command still works correctly in all modes

🤖 Generated with [Claude Code](https://claude.ai/code)