### PR TITLE
docs: convert author section from markdown to HTML table

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🐦️ Author
 
-| | |
-|---|---|
-| <img src="https://github.com/haya14busa.png" width="60" height="60" alt="haya14busa" /> | **haya14busa**<br/>[![GitHub followers](https://img.shields.io/github/followers/haya14busa.svg?style=flat&label=Follow&logo=github)](https://github.com/haya14busa) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?style=flat&logo=github-sponsors&logoColor=white)](https://github.com/sponsors/haya14busa) |
+<table>
+  <tr>
+    <td><img src="https://github.com/haya14busa.png" width="60" height="60" alt="haya14busa" /></td>
+    <td><b>haya14busa</b><br/><a href="https://github.com/haya14busa"><img src="https://img.shields.io/github/followers/haya14busa.svg?style=flat&label=Follow&logo=github" alt="GitHub followers" /></a> <a href="https://github.com/sponsors/haya14busa"><img src="https://img.shields.io/badge/Sponsor-EA4AAA?style=flat&logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" /></a></td>
+  </tr>
+</table>


### PR DESCRIPTION
## Summary
- Convert the author section in README.md from a Markdown table to an HTML table
- This provides cleaner presentation without the unnecessary table headers

## Test plan
- [x] Verified the HTML renders correctly in GitHub's README preview
- [x] All links and images remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)