### PR TITLE
docs: fix placeholder documentation in schema

### DIFF
--- a/pkg/spec/generated.go
+++ b/pkg/spec/generated.go
@@ -126,7 +126,8 @@ type Asset struct {
 	//
 	// Available placeholders:
 	// - ${NAME}: Binary name (from 'name' field or repository name)
-	// - ${VERSION}: Version to install (includes 'v' prefix if present in tag)
+	// - ${VERSION}: Version to install (without 'v' prefix, e.g., '1.0.0')
+	// - ${TAG}: Original tag with 'v' prefix if present (e.g., 'v1.0.0')
 	// - ${OS}: Operating system (e.g., 'linux', 'darwin', 'windows')
 	// - ${ARCH}: Architecture (e.g., 'amd64', 'arm64', '386')
 	// - ${EXT}: File extension (from 'default_extension' or rules)
@@ -376,7 +377,7 @@ type Checksums struct {
 	// Pre-verified checksums organized by version.
 	//
 	// Use 'binst embed-checksums' command to automatically populate this.
-	// The key is the version string (includes 'v' prefix if present in tag).
+	// The key is the version string (includes 'v' prefix if present in tag, e.g., 'v1.0.0').
 	// The value is an array of filename/hash pairs.
 	//
 	// This allows offline installation and protects against

--- a/schema/main.tsp
+++ b/schema/main.tsp
@@ -224,7 +224,8 @@ model AssetConfig {
     
     Available placeholders:
     - \${NAME}: Binary name (from 'name' field or repository name)
-    - \${VERSION}: Version to install (includes 'v' prefix if present in tag)
+    - \${VERSION}: Version to install (without 'v' prefix, e.g., '1.0.0')
+    - \${TAG}: Original tag with 'v' prefix if present (e.g., 'v1.0.0')
     - \${OS}: Operating system (e.g., 'linux', 'darwin', 'windows')
     - \${ARCH}: Architecture (e.g., 'amd64', 'arm64', '386')
     - \${EXT}: File extension (from 'default_extension' or rules)
@@ -529,7 +530,7 @@ model ChecksumConfig {
     Pre-verified checksums organized by version.
     
     Use 'binst embed-checksums' command to automatically populate this.
-    The key is the version string (includes 'v' prefix if present in tag).
+    The key is the version string (includes 'v' prefix if present in tag, e.g., 'v1.0.0').
     The value is an array of filename/hash pairs.
     
     This allows offline installation and protects against

--- a/schema/output/@typespec/json-schema/InstallSpec.json
+++ b/schema/output/@typespec/json-schema/InstallSpec.json
@@ -58,7 +58,7 @@
             "properties": {
                 "template": {
                     "type": "string",
-                    "description": "Filename template with placeholders.\n\nAvailable placeholders:\n- ${NAME}: Binary name (from 'name' field or repository name)\n- ${VERSION}: Version to install (includes 'v' prefix if present in tag)\n- ${OS}: Operating system (e.g., 'linux', 'darwin', 'windows')\n- ${ARCH}: Architecture (e.g., 'amd64', 'arm64', '386')\n- ${EXT}: File extension (from 'default_extension' or rules)\n\nExamples:\n- \"${NAME}_${VERSION}_${OS}_${ARCH}.tar.gz\"\n- \"${NAME}-${VERSION}-${OS}-${ARCH}${EXT}\"\n- \"v${VERSION}/${NAME}_${OS}_${ARCH}.zip\""
+                    "description": "Filename template with placeholders.\n\nAvailable placeholders:\n- ${NAME}: Binary name (from 'name' field or repository name)\n- ${VERSION}: Version to install (without 'v' prefix, e.g., '1.0.0')\n- ${TAG}: Original tag with 'v' prefix if present (e.g., 'v1.0.0')\n- ${OS}: Operating system (e.g., 'linux', 'darwin', 'windows')\n- ${ARCH}: Architecture (e.g., 'amd64', 'arm64', '386')\n- ${EXT}: File extension (from 'default_extension' or rules)\n\nExamples:\n- \"${NAME}_${VERSION}_${OS}_${ARCH}.tar.gz\"\n- \"${NAME}-${VERSION}-${OS}-${ARCH}${EXT}\"\n- \"v${VERSION}/${NAME}_${OS}_${ARCH}.zip\""
                 },
                 "default_extension": {
                     "type": "string",
@@ -131,7 +131,7 @@
                 },
                 "embedded_checksums": {
                     "$ref": "#/$defs/RecordArrayEmbeddedChecksum",
-                    "description": "Pre-verified checksums organized by version.\n\nUse 'binst embed-checksums' command to automatically populate this.\nThe key is the version string (includes 'v' prefix if present in tag).\nThe value is an array of filename/hash pairs.\n\nThis allows offline installation and protects against\ncompromised checksum files."
+                    "description": "Pre-verified checksums organized by version.\n\nUse 'binst embed-checksums' command to automatically populate this.\nThe key is the version string (includes 'v' prefix if present in tag, e.g., 'v1.0.0').\nThe value is an array of filename/hash pairs.\n\nThis allows offline installation and protects against\ncompromised checksum files."
                 }
             },
             "quicktypePropertyOrder": [


### PR DESCRIPTION
## Summary
- Fixed incorrect documentation for `${VERSION}` placeholder - it strips the 'v' prefix, not includes it
- Added documentation for the `${TAG}` placeholder that was missing
- Clarified that embedded_checksums keys include the 'v' prefix

## Test plan
- [x] Documentation changes only
- [x] Ran `make gen` to regenerate Go structs and JSON schema

🤖 Generated with [Claude Code](https://claude.ai/code)