### PR TITLE
refactor: move permissions to job-level in generate-installer workflow

### DIFF
--- a/.github/workflows/generate-installer.yml
+++ b/.github/workflows/generate-installer.yml
@@ -5,15 +5,14 @@ on:
     branches: [main]
     paths: ['.config/binstaller.yml']
 
-permissions:
-  contents: write
-  pull-requests: write
-  attestations: write
-  id-token: write
-
 jobs:
   generate-and-attest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      attestations: write
+      id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2


### PR DESCRIPTION
## Summary
- Move permissions from workflow top-level to job-level in `generate-installer.yml`
- Provides better granularity and follows security best practices
- No functional changes to the workflow behavior

## Test plan
- [ ] Verify workflow runs successfully with job-level permissions
- [ ] Confirm all permissions work correctly at job level

🤖 Generated with [Claude Code](https://claude.ai/code)