### PR TITLE
Improve test performance with Go's -short flag

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -32,6 +32,10 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
+      with:
+        aqua_version: v2.50.0
+
     - name: Install dependencies
       run: make setup
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,11 @@ jobs:
       with:
         deno-version: vx.x.x
 
-    - run: make setup
-
     - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
       with:
         aqua_version: v2.50.0
+
+    - run: make setup
 
     - run: make ci
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -14,5 +14,6 @@ packages:
 - name: mikefarah/yq@v4.45.1
 - name: mvdan/sh@v3.11.0
 - name: koalaman/shellcheck@v0.10.0
-- name: golangci/golangci-lint@v2.1.2
+- name: golangci/golangci-lint@v2.2.1
 - name: shenwei356/rush@v0.6.1
+- name: goreleaser/goreleaser@v2.5.1

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -118,27 +118,45 @@ func testInstallScript(t *testing.T, repo, binaryName, versionFlag, sha string) 
 }
 
 func TestReviewdogE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
 	testInstallScript(t, "reviewdog/reviewdog", "reviewdog", "-version", "7e05fa3e78ba7f2be4999ca2d35b00a3fd92a783")
 }
 
 func TestGoreleaserE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
 	testInstallScript(t, "goreleaser/goreleaser", "goreleaser", "--version", "79c76c229d50ca45ef77afa1745df0a0e438d237")
 }
 
 func TestGhSetupE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
 	testInstallScript(t, "k1LoW/gh-setup", "gh-setup", "--help", "a2359e4bcda8af5d7e16e1b3fb0eeec1be267e63")
 }
 
 func TestSigspyE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
 	testInstallScript(t, "actionutils/sigspy", "sigspy", "--help", "3e1c6f32072cd4b8309d00bd31f498903f71c422")
 }
 
 func TestGolangciLintE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
 	testInstallScript(t, "golangci/golangci-lint", "golangci-lint", "--version", "6d2a94be6b20f1c06e95d79479c6fdc34a69c45f")
 }
 
 // TestTargetVersionGeneration tests the --target-version flag functionality
 func TestTargetVersionGeneration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
 	// Create a temporary directory for test artifacts
 	tempDir := t.TempDir()
 
@@ -261,6 +279,9 @@ supported_platforms:
 
 // TestTargetVersionFlag tests the CLI flag validation
 func TestTargetVersionFlag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
 	tempDir := t.TempDir()
 
 	// Create a minimal test config


### PR DESCRIPTION
## Summary
- Replaced slow `make test` that runs E2E tests with fast unit tests using Go's `-short` flag
- Significantly improves development iteration speed from ~30s to ~1s
- Maintains comprehensive testing via `make test-all` for CI and pre-release checks

## Test plan
- [x] `make test` runs in ~1 second (unit tests only)
- [x] `make test-all` runs all tests including E2E (~30 seconds)
- [x] E2E tests properly skip with `testing.Short()` check
- [x] CI still runs comprehensive tests via `make test-all`

🤖 Generated with [Claude Code](https://claude.ai/code)