### PR TITLE
ci: add binst check validation to test-installer workflow

### DIFF
--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Build binst
         run: go build -o binst ./cmd/binst
 
+      - name: Check binstaller config
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔍 Validating binstaller configuration..."
+          ./binst check
+          echo "✅ Configuration validation passed"
+
       - name: Generate test install script
         run: ./binst gen -o test-install.sh
 


### PR DESCRIPTION
## Summary

This PR adds `binst check` command execution to the test-installer workflow to validate the binstaller configuration before generating install scripts.

## Changes

- Add configuration validation step in `.github/workflows/test-installer.yml`
- Run `binst check` before generating test install script
- This ensures the configuration is valid before attempting to generate scripts

## Purpose

When `.config/binstaller.yml` is modified, the workflow will now:
1. First validate the configuration using `binst check`
2. Only proceed to generate install scripts if validation passes
3. This helps catch configuration errors early in the CI pipeline

## Note

This PR includes the `bump:minor` label to trigger a minor version release. This release will include the previously merged PR #81 (feat: add test sub command to validate InstallSpec config files), which was merged without a release label.