### PR TITLE
fix: handle missing checksums field in embed-checksums command

### DIFF
--- a/pkg/checksums/checksums.go
+++ b/pkg/checksums/checksums.go
@@ -131,8 +131,17 @@ func (e *Embedder) Embed() error {
 	if err != nil {
 		return err
 	}
+	// Try to merge into the existing checksums field, or replace it if it doesn't exist
 	if err := p.MergeFromNode(e.SpecAST, node); err != nil {
-		return err
+		// If merge fails (likely because checksums field doesn't exist), replace the entire field
+		if strings.Contains(err.Error(), "node not found") {
+			// Replace the entire checksums field in the AST
+			if err := p.ReplaceWithNode(e.SpecAST, node); err != nil {
+				return fmt.Errorf("failed to create checksums field: %w", err)
+			}
+		} else {
+			return err
+		}
 	}
 	return nil
 }

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,0 +1,17 @@
+name: shellcheck
+repo: koalaman/shellcheck
+assets:
+  - template: "shellcheck-${VERSION}.${OS}.${ARCH}.tar.xz"
+    os_mapping:
+      linux: linux
+      darwin: darwin
+      windows: windows
+    arch_mapping:
+      x86_64: x86_64
+      aarch64: aarch64
+    replacements:
+      windows: 
+        ext: zip
+        template: "shellcheck-${VERSION}.${OS}.${ARCH}.zip"
+env:
+  SHELLCHECK_VERSION: "${VERSION}"


### PR DESCRIPTION
Fixes issue where `embed-checksums --mode=calculate` fails when checksums field is not present in config.

The command was failing with "failed to find path ( $.checksums ): node not found" when the checksums field was missing from the configuration file.

This fix catches the "node not found" error and uses ReplaceWithNode to create the checksums field if it doesn't exist, allowing the command to work with config files that don't have a checksums section.

Fixes #84

Generated with [Claude Code](https://claude.ai/code)