### PR TITLE
Add confirmation prompt and --force flag to binst init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ $(JSON_SCHEMA): $(TYPESPEC_SOURCES)
 
 $(GENERATED_GO): $(JSON_SCHEMA)
 	@echo "Generating Go structs from JSON Schema..."
-	@cd $(SCHEMA_DIR) && npm run gen:go
+	@cd $(SCHEMA_DIR) && npm install --silent && npm run gen:go
 
 $(YAML_SCHEMA): $(JSON_SCHEMA) aqua-install
 	@echo "Generating YAML Schema from JSON Schema..."

--- a/test/gen_config.sh
+++ b/test/gen_config.sh
@@ -1,35 +1,35 @@
 #!/bin/bash
 set -e
 # Test goreleaser source
-./binst init --source goreleaser --repo reviewdog/reviewdog -o=testdata/reviewdog.binstaller.yml --sha='7e05fa3e78ba7f2be4999ca2d35b00a3fd92a783'
-./binst init --source goreleaser --repo actionutils/sigspy -o=testdata/sigspy.binstaller.yml --sha='3e1c6f32072cd4b8309d00bd31f498903f71c422'
-./binst init --source goreleaser --repo junegunn/fzf -o=testdata/fzf.binstaller.yml --sha='ce95adc66c27d97b8f1bb56f139b7efd3f53e5c4'
-./binst init --source goreleaser --repo k1LoW/gh-setup -o=testdata/gh-setup.binstaller.yml --sha='f59adf10c4c7ed2b673a9f0a96fc1f8a37a735bd'
+./binst init --force --source goreleaser --repo reviewdog/reviewdog -o=testdata/reviewdog.binstaller.yml --sha='7e05fa3e78ba7f2be4999ca2d35b00a3fd92a783'
+./binst init --force --source goreleaser --repo actionutils/sigspy -o=testdata/sigspy.binstaller.yml --sha='3e1c6f32072cd4b8309d00bd31f498903f71c422'
+./binst init --force --source goreleaser --repo junegunn/fzf -o=testdata/fzf.binstaller.yml --sha='ce95adc66c27d97b8f1bb56f139b7efd3f53e5c4'
+./binst init --force --source goreleaser --repo k1LoW/gh-setup -o=testdata/gh-setup.binstaller.yml --sha='f59adf10c4c7ed2b673a9f0a96fc1f8a37a735bd'
 # Test aqua source
-./binst init --source aqua --repo zyedidia/micro --output=testdata/micro.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
-./binst init --source aqua --repo houseabsolute/ubi --output=testdata/ubi.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo zyedidia/micro --output=testdata/micro.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo houseabsolute/ubi --output=testdata/ubi.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test rosetta2
-./binst init --source aqua --repo ducaale/xh --output=testdata/xh.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo ducaale/xh --output=testdata/xh.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test rosetta2 in version overrides
-./binst init --source aqua --repo babarot/git-bump --output=testdata/git-bump.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo babarot/git-bump --output=testdata/git-bump.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test empty extension (extension hard coded in template)
-./binst init --source aqua --repo Lallassu/gorss --output=testdata/gorss.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo Lallassu/gorss --output=testdata/gorss.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Checksum file only contains hash (it does not file name).
-./binst init --source aqua --repo EmbarkStudios/cargo-deny --output=testdata/cargo-deny.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo EmbarkStudios/cargo-deny --output=testdata/cargo-deny.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Checksum file contains `*<file name>` (binary mode. e.g. sha256sum -b)
-./binst init --source aqua --repo int128/kauthproxy --output=testdata/kauthproxy.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo int128/kauthproxy --output=testdata/kauthproxy.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test .tar.bz2
-./binst init --source aqua --repo xo/xo --output=testdata/xo.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo xo/xo --output=testdata/xo.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test .gz
-./binst init --source aqua --repo tree-sitter/tree-sitter --output=testdata/treesitter.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo tree-sitter/tree-sitter --output=testdata/treesitter.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test AssetWithoutExt
-./binst init --source aqua --repo Byron/dua-cli --output=testdata/dua-cli.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo Byron/dua-cli --output=testdata/dua-cli.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test replacement in override (should not merge rule)
-./binst init --source aqua --repo SuperCuber/dotter --output=testdata/dotter.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo SuperCuber/dotter --output=testdata/dotter.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 # Test github source
-./binst init --source github --repo haya14busa/bump --output=testdata/bump.binstaller.yml
+./binst init --force --source github --repo haya14busa/bump --output=testdata/bump.binstaller.yml
 # Test default bin dir with yq modification
-./binst init --source github --repo charmbracelet/gum --output=testdata/gum.binstaller.yml
+./binst init --force --source github --repo charmbracelet/gum --output=testdata/gum.binstaller.yml
 echo '# --- manually added ---' >> testdata/gum.binstaller.yml
 yq -i '.unpack.strip_components = 1' testdata/gum.binstaller.yml
 yq -i '.default_bindir = "./bin"' testdata/gum.binstaller.yml

--- a/test/gen_config.sh
+++ b/test/gen_config.sh
@@ -43,5 +43,5 @@ yq -i '.asset.rules += [{"when": {"os": "openbsd"}, "os": "Openbsd"}]' testdata/
 ./binst embed-checksums -c ./testdata/gum.binstaller.yml -m download --version v0.15.0
 ./binst embed-checksums -c ./testdata/gum.binstaller.yml -m download --version v0.16.0
 # Test GitHub release digest
-./binst init --source aqua --repo Songmu/tagpr --output=testdata/tagpr.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
+./binst init --force --source aqua --repo Songmu/tagpr --output=testdata/tagpr.binstaller.yml --sha='1436b9b02096f39ace945d9c56adb7a5b11df186'
 ./binst embed-checksums -c ./testdata/tagpr.binstaller.yml  --mode calculate --version v1.7.0


### PR DESCRIPTION
This PR addresses Issue #95 by adding file overwrite protection to the `binst init` command.

## Changes
- Add file existence check before writing config files
- Prompt user for confirmation when overwriting existing files
- Add `--force` flag to skip confirmation for automation scenarios
- Update help text with usage example
- Maintain backward compatibility

## Testing
- ✅ Build: Successful compilation
- ✅ Linting: 0 issues found
- ✅ Tests: All tests pass

Fixes #95

Generated with [Claude Code](https://claude.ai/code)