### PR TITLE
Optimize Claude code review workflow execution

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -33,8 +33,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Use Claude Opus 4 for more thorough initial review
+          model: "claude-opus-4-20250514"
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
@@ -44,6 +44,13 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
+            - Maintainability aspects:
+              - Code readability and clarity
+              - Appropriate abstractions and modularity
+              - Documentation quality (comments, function docs)
+              - Error handling patterns
+              - Naming conventions consistency
+              - Future extensibility considerations
             
             Be constructive and helpful in your feedback.
 


### PR DESCRIPTION
## Summary
- Run Claude code review only on PR open (not on every update)
- Switch to Claude Opus 4 model for more thorough initial reviews
- Enhance review criteria with maintainability aspects

## Changes
- Modified `.github/workflows/claude-code-review.yml`:
  - Changed trigger from `[opened, synchronize]` to `[opened]` only
  - Enabled Claude Opus 4 model for better code analysis
  - Added maintainability review criteria (readability, modularity, documentation, error handling, naming conventions, extensibility)

## Rationale
Running code reviews on every PR update was excessive. With this change:
- Initial PR gets a comprehensive review with Opus 4
- Additional reviews can be requested via `@claude` mentions in comments
- Reduces unnecessary workflow runs while maintaining code quality

🤖 Generated with [Claude Code](https://claude.ai/code)