### PR TITLE
docs: soften GITHUB_TOKEN recommendation for check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Understanding the status indicators:
 - `⚠ NOT SUPPORTED` - Feature not supported (e.g., per-asset checksums)
 - `-` - Ignored file (docs, signatures, package formats like .deb/.dmg)
 
-**Note:** We strongly recommend setting `GITHUB_TOKEN` when using the `check` command to avoid GitHub API rate limits:
+**Note:** Setting `GITHUB_TOKEN` is optional but recommended when using the `check` command to avoid GitHub API rate limits:
 
 ```bash
 export GITHUB_TOKEN=$(gh auth token)


### PR DESCRIPTION
Fixes #103

Change 'strongly recommend' to 'optional but recommended' for GITHUB_TOKEN usage with the check command. The check command only makes 1-2 light API calls and should typically work without authentication.

Generated with [Claude Code](https://claude.ai/code)