### PR TITLE
fix: Add chmod +x to runner scripts for executable permissions

### DIFF
--- a/internal/shell/script_test.go
+++ b/internal/shell/script_test.go
@@ -521,6 +521,7 @@ func TestGenerateRunner(t *testing.T) {
 				`exec "${BINARY_PATH}" $TOOL_ARGS`,
 				`cleanup() {`,
 				`trap cleanup EXIT HUP INT TERM`,
+				`chmod +x "${BINARY_PATH}"`,
 			},
 			wantNotContain: []string{
 				`install "${BINARY_PATH}" "${INSTALL_PATH}"`,
@@ -543,6 +544,7 @@ func TestGenerateRunner(t *testing.T) {
 				`# This script runs test-tool directly without installing`,
 				`TAG="v1.2.3"`,
 				`exec "${BINARY_PATH}" $TOOL_ARGS`,
+				`chmod +x "${BINARY_PATH}"`,
 			},
 			wantNotContain: []string{
 				`TAG="${1:-latest}"`,
@@ -620,7 +622,8 @@ func TestGenerateWithScriptType(t *testing.T) {
 			scriptType: "installer",
 			wantError:  false,
 			checkFunc: func(script string) bool {
-				return strings.Contains(script, `install "${BINARY_PATH}" "${INSTALL_PATH}"`)
+				return strings.Contains(script, `install "${BINARY_PATH}" "${INSTALL_PATH}"`) &&
+					!strings.Contains(script, `chmod +x "${BINARY_PATH}"`)
 			},
 		},
 		{
@@ -636,7 +639,8 @@ func TestGenerateWithScriptType(t *testing.T) {
 			scriptType: "runner",
 			wantError:  false,
 			checkFunc: func(script string) bool {
-				return strings.Contains(script, `exec "${BINARY_PATH}" $TOOL_ARGS`)
+				return strings.Contains(script, `exec "${BINARY_PATH}" $TOOL_ARGS`) &&
+					strings.Contains(script, `chmod +x "${BINARY_PATH}"`)
 			},
 		},
 		{
@@ -652,7 +656,8 @@ func TestGenerateWithScriptType(t *testing.T) {
 			scriptType: "",
 			wantError:  false,
 			checkFunc: func(script string) bool {
-				return strings.Contains(script, `install "${BINARY_PATH}" "${INSTALL_PATH}"`)
+				return strings.Contains(script, `install "${BINARY_PATH}" "${INSTALL_PATH}"`) &&
+					!strings.Contains(script, `chmod +x "${BINARY_PATH}"`)
 			},
 		},
 		{

--- a/internal/shell/template.tmpl.sh
+++ b/internal/shell/template.tmpl.sh
@@ -382,6 +382,8 @@ execute() {
   {{- if eq $.ScriptType "installer" }}
   {{- template "execute_install" $ }}
   {{- else }}
+  # Make binary executable for runner script
+  chmod +x "${BINARY_PATH}"
   {{- template "execute_run" $ }}
   {{- end }}
   {{- end }}

--- a/internal/shell/template.tmpl.sh
+++ b/internal/shell/template.tmpl.sh
@@ -339,6 +339,8 @@ cleanup() {
 {{- end }}
 
 {{- define "execute_run" }}
+  # Make binary executable for runner script
+  chmod +x "${BINARY_PATH}"
   # Run the binary directly with provided arguments
   log_info "Running ${BINARY_NAME}${TOOL_ARGS:+ with arguments:$TOOL_ARGS}"
   exec "${BINARY_PATH}" $TOOL_ARGS
@@ -382,8 +384,6 @@ execute() {
   {{- if eq $.ScriptType "installer" }}
   {{- template "execute_install" $ }}
   {{- else }}
-  # Make binary executable for runner script
-  chmod +x "${BINARY_PATH}"
   {{- template "execute_run" $ }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Fixes issue where generated runner scripts may fail if downloaded binaries don't have executable permissions by default.

## Changes
- Add chmod +x command to runner script template before execution
- Update tests to verify chmod command is present in runner scripts
- Ensure installer scripts continue to work without chmod (install command handles permissions)

Closes #102

Generated with [Claude Code](https://claude.ai/code)