### PR TITLE
fix: add AQUA_GITHUB_TOKEN to setup action to avoid API rate limits

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,3 +12,5 @@ runs:
     - name: Build binst
       shell: bash
       run: make build
+      env:
+        AQUA_GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

This PR adds the `AQUA_GITHUB_TOKEN` environment variable to the setup action to prevent GitHub API rate limit issues.

### Problem

The `make build` command in the setup action internally calls aqua, which can hit GitHub API rate limits during tool installation.

### Solution

Set `AQUA_GITHUB_TOKEN` using the built-in `github.token` when running `make build` in the setup action. This provides authenticated API access and significantly higher rate limits.

### Changes

- Added `AQUA_GITHUB_TOKEN: ${{ github.token }}` to the environment variables for the "Build binst" step in `.github/actions/setup/action.yml`

This is a minimal fix that only affects the setup action where aqua is actually used during the build process.

🤖 Generated with [Claude Code](https://claude.ai/code)