### PR TITLE
feat: add --binary flag for runner scripts with multiple binaries

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/binary-install/binstaller/internal/cmdutil"
 	"github.com/binary-install/binstaller/pkg/asset"
 	"github.com/binary-install/binstaller/pkg/httpclient"
 	"github.com/binary-install/binstaller/pkg/spec"
@@ -85,7 +84,7 @@ Exit Codes:
 		log.Debugf("Using config file: %s", cfgFile)
 
 		// Load and parse InstallSpec
-		installSpec, err := cmdutil.LoadInstallSpec(cfgFile)
+		installSpec, err := loadInstallSpec(cfgFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -56,6 +56,121 @@ func findBinaryByName(binaries []spec.BinaryElement, name string) (*spec.BinaryE
 	return nil, false
 }
 
+// loadInstallSpec loads and parses the InstallSpec from the config file
+func loadInstallSpec(cfgFile string) (*spec.InstallSpec, error) {
+	// Read the InstallSpec YAML file
+	log.Debugf("Reading InstallSpec from: %s", cfgFile)
+	var yamlData []byte
+	var err error
+
+	if cfgFile == "-" {
+		log.Debug("Reading install spec from stdin")
+		yamlData, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			log.WithError(err).Error("Failed to read install spec from stdin")
+			return nil, fmt.Errorf("failed to read install spec from stdin: %w", err)
+		}
+	} else {
+		yamlData, err = os.ReadFile(cfgFile)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to read install spec file: %s", cfgFile)
+			return nil, fmt.Errorf("failed to read install spec file %s: %w", cfgFile, err)
+		}
+	}
+
+	// Unmarshal YAML into InstallSpec struct
+	log.Debug("Unmarshalling InstallSpec YAML")
+	var installSpec spec.InstallSpec
+	err = yaml.Unmarshal(yamlData, &installSpec)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to unmarshal install spec YAML from: %s", cfgFile)
+		return nil, fmt.Errorf("failed to unmarshal install spec YAML from %s: %w", cfgFile, err)
+	}
+
+	return &installSpec, nil
+}
+
+// handleRunnerBinarySelection handles binary selection logic for runner scripts
+func handleRunnerBinarySelection(installSpec *spec.InstallSpec, scriptType, binaryName string) error {
+	// Only apply to runner scripts
+	if scriptType != "runner" {
+		return nil
+	}
+
+	// Check if we need to handle binary selection
+	if installSpec.Asset == nil || len(installSpec.Asset.Binaries) <= 1 {
+		// Single binary or no binaries - check if binary flag was unnecessarily used
+		if binaryName != "" && len(installSpec.Asset.Binaries) <= 1 {
+			log.Warnf("--binary flag specified but configuration has only one binary. Ignoring flag.")
+		}
+		return nil
+	}
+
+	// Multiple binaries case
+	if binaryName == "" {
+		// No binary specified - use first one with warning
+		firstBinary := installSpec.Asset.Binaries[0]
+		binaryName := ""
+		if firstBinary.Name != nil && *firstBinary.Name != "" {
+			binaryName = *firstBinary.Name
+		}
+		log.Warnf("Multiple binaries found. Generating runner for the first binary '%s'.", binaryName)
+		log.Warnf("Use --binary flag to specify a different binary.")
+
+		availableBinaries := getAvailableBinaryNames(installSpec.Asset.Binaries)
+		if len(availableBinaries) > 0 {
+			log.Infof("Available binaries: %s", strings.Join(availableBinaries, ", "))
+		}
+		// Keep only the first binary
+		installSpec.Asset.Binaries = installSpec.Asset.Binaries[:1]
+	} else {
+		// Binary specified - validate and select it
+		selectedBinary, found := findBinaryByName(installSpec.Asset.Binaries, binaryName)
+		if !found {
+			log.Errorf("Binary '%s' not found in configuration", binaryName)
+			availableBinaries := getAvailableBinaryNames(installSpec.Asset.Binaries)
+			if len(availableBinaries) > 0 {
+				log.Errorf("Available binaries: %s", strings.Join(availableBinaries, ", "))
+			}
+			return fmt.Errorf("binary '%s' not found", binaryName)
+		}
+
+		// Filter installSpec to only include the selected binary
+		installSpec.Asset.Binaries = []spec.BinaryElement{*selectedBinary}
+		log.Infof("Generating runner for binary '%s'", binaryName)
+	}
+
+	return nil
+}
+
+// writeScript writes the generated script to the specified output
+func writeScript(scriptBytes []byte, outputFile, scriptType string) error {
+	if outputFile == "" || outputFile == "-" {
+		// Write to stdout
+		log.Debugf("Writing %s script to stdout", scriptType)
+		fmt.Print(string(scriptBytes))
+		log.Infof("%s script written to stdout", scriptType)
+	} else {
+		// Write to file
+		log.Infof("Writing %s script to file: %s", scriptType, outputFile)
+
+		// Ensure the output directory exists
+		outputDir := filepath.Dir(outputFile)
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			log.WithError(err).Errorf("Failed to create output directory: %s", outputDir)
+			return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
+		}
+
+		err := os.WriteFile(outputFile, scriptBytes, 0755) // Make script executable
+		if err != nil {
+			log.WithError(err).Errorf("Failed to write %s script to file: %s", scriptType, outputFile)
+			return fmt.Errorf("failed to write %s script to file %s: %w", scriptType, outputFile, err)
+		}
+		log.Infof("%s script successfully written to %s", scriptType, outputFile)
+	}
+	return nil
+}
+
 // GenCommand represents the gen command
 var GenCommand = &cobra.Command{
 	Use:   "gen",
@@ -110,18 +225,16 @@ generates a POSIX-compatible shell installer script.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info("Running gen command...")
 
-		// Validate script type
+		// Validate and normalize script type
 		if err := validateScriptType(genScriptType); err != nil {
 			log.WithError(err).Error("Invalid script type")
 			return err
 		}
-
-		// Default to installer if not specified
 		if genScriptType == "" {
 			genScriptType = "installer"
 		}
 
-		// Determine config file path using common logic
+		// Resolve config file path
 		cfgFile, err := resolveConfigFile(configFile)
 		if err != nil {
 			log.WithError(err).Error("Config file detection failed")
@@ -132,108 +245,28 @@ generates a POSIX-compatible shell installer script.`,
 		}
 		log.Debugf("Using config file: %s", cfgFile)
 
-		// Read the InstallSpec YAML file
-		log.Debugf("Reading InstallSpec from: %s", cfgFile)
-		var yamlData []byte
-		if cfgFile == "-" {
-			log.Debug("Reading install spec from stdin")
-			yamlData, err = io.ReadAll(os.Stdin)
-			if err != nil {
-				log.WithError(err).Error("Failed to read install spec from stdin")
-				return fmt.Errorf("failed to read install spec from stdin: %w", err)
-			}
-		} else {
-			yamlData, err = os.ReadFile(cfgFile)
-			if err != nil {
-				log.WithError(err).Errorf("Failed to read install spec file: %s", cfgFile)
-				return fmt.Errorf("failed to read install spec file %s: %w", cfgFile, err)
-			}
-		}
-
-		// Unmarshal YAML into InstallSpec struct
-		log.Debug("Unmarshalling InstallSpec YAML")
-		var installSpec spec.InstallSpec
-		err = yaml.Unmarshal(yamlData, &installSpec)
+		// Load and parse InstallSpec
+		installSpec, err := loadInstallSpec(cfgFile)
 		if err != nil {
-			log.WithError(err).Errorf("Failed to unmarshal install spec YAML from: %s", cfgFile)
-			return fmt.Errorf("failed to unmarshal install spec YAML from %s: %w", cfgFile, err)
+			return err
 		}
 
 		// Handle binary selection for runner scripts
-		if genScriptType == "runner" && installSpec.Asset != nil && len(installSpec.Asset.Binaries) > 1 {
-			if genBinaryName == "" {
-				// Warning: multiple binaries found, using the first one
-				firstBinary := installSpec.Asset.Binaries[0]
-				binaryName := ""
-				if firstBinary.Name != nil && *firstBinary.Name != "" {
-					binaryName = *firstBinary.Name
-				}
-				log.Warnf("Multiple binaries found. Generating runner for the first binary '%s'.", binaryName)
-				log.Warnf("Use --binary flag to specify a different binary.")
-
-				// Available binaries for reference
-				availableBinaries := getAvailableBinaryNames(installSpec.Asset.Binaries)
-				if len(availableBinaries) > 0 {
-					log.Infof("Available binaries: %s", strings.Join(availableBinaries, ", "))
-				}
-			} else {
-				// Validate the specified binary exists
-				selectedBinary, found := findBinaryByName(installSpec.Asset.Binaries, genBinaryName)
-
-				if !found {
-					log.Errorf("Binary '%s' not found in configuration", genBinaryName)
-					availableBinaries := getAvailableBinaryNames(installSpec.Asset.Binaries)
-					if len(availableBinaries) > 0 {
-						log.Errorf("Available binaries: %s", strings.Join(availableBinaries, ", "))
-					}
-					return fmt.Errorf("binary '%s' not found", genBinaryName)
-				}
-
-				// Filter installSpec to only include the selected binary
-				installSpec.Asset.Binaries = []spec.BinaryElement{*selectedBinary}
-				log.Infof("Generating runner for binary '%s'", genBinaryName)
-			}
-		} else if genScriptType == "runner" && genBinaryName != "" {
-			// Warning: --binary flag used but not needed
-			if installSpec.Asset == nil || len(installSpec.Asset.Binaries) <= 1 {
-				log.Warnf("--binary flag specified but configuration has only one binary. Ignoring flag.")
-			}
+		if err := handleRunnerBinarySelection(installSpec, genScriptType, genBinaryName); err != nil {
+			return err
 		}
 
-		// Generate the script using the internal shell generator
+		// Generate the script
 		log.Infof("Generating %s script...", genScriptType)
-		scriptBytes, err := shell.GenerateWithScriptType(&installSpec, genTargetVersion, genScriptType)
+		scriptBytes, err := shell.GenerateWithScriptType(installSpec, genTargetVersion, genScriptType)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to generate %s script", genScriptType)
 			return fmt.Errorf("failed to generate %s script: %w", genScriptType, err)
 		}
 		log.Debugf("%s script generated successfully", genScriptType)
 
-		// Write the output script
-		if genOutputFile == "" || genOutputFile == "-" {
-			// Write to stdout
-			log.Debugf("Writing %s script to stdout", genScriptType)
-			fmt.Print(string(scriptBytes))
-			log.Infof("%s script written to stdout", genScriptType)
-		} else {
-			// Write to file
-			log.Infof("Writing %s script to file: %s", genScriptType, genOutputFile)
-			// Ensure the output directory exists
-			outputDir := filepath.Dir(genOutputFile)
-			if err := os.MkdirAll(outputDir, 0755); err != nil {
-				log.WithError(err).Errorf("Failed to create output directory: %s", outputDir)
-				return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
-			}
-
-			err = os.WriteFile(genOutputFile, scriptBytes, 0755) // Make script executable
-			if err != nil {
-				log.WithError(err).Errorf("Failed to write %s script to file: %s", genScriptType, genOutputFile)
-				return fmt.Errorf("failed to write %s script to file %s: %w", genScriptType, genOutputFile, err)
-			}
-			log.Infof("%s script successfully written to %s", genScriptType, genOutputFile)
-		}
-
-		return nil
+		// Write the output
+		return writeScript(scriptBytes, genOutputFile, genScriptType)
 	},
 }
 

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -2,15 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/binary-install/binstaller/internal/cmdutil"
 	"github.com/binary-install/binstaller/internal/shell" // Placeholder for script generator
 	"github.com/binary-install/binstaller/pkg/spec"
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 )
 
@@ -54,40 +53,6 @@ func findBinaryByName(binaries []spec.BinaryElement, name string) (*spec.BinaryE
 		}
 	}
 	return nil, false
-}
-
-// loadInstallSpec loads and parses the InstallSpec from the config file
-func loadInstallSpec(cfgFile string) (*spec.InstallSpec, error) {
-	// Read the InstallSpec YAML file
-	log.Debugf("Reading InstallSpec from: %s", cfgFile)
-	var yamlData []byte
-	var err error
-
-	if cfgFile == "-" {
-		log.Debug("Reading install spec from stdin")
-		yamlData, err = io.ReadAll(os.Stdin)
-		if err != nil {
-			log.WithError(err).Error("Failed to read install spec from stdin")
-			return nil, fmt.Errorf("failed to read install spec from stdin: %w", err)
-		}
-	} else {
-		yamlData, err = os.ReadFile(cfgFile)
-		if err != nil {
-			log.WithError(err).Errorf("Failed to read install spec file: %s", cfgFile)
-			return nil, fmt.Errorf("failed to read install spec file %s: %w", cfgFile, err)
-		}
-	}
-
-	// Unmarshal YAML into InstallSpec struct
-	log.Debug("Unmarshalling InstallSpec YAML")
-	var installSpec spec.InstallSpec
-	err = yaml.Unmarshal(yamlData, &installSpec)
-	if err != nil {
-		log.WithError(err).Errorf("Failed to unmarshal install spec YAML from: %s", cfgFile)
-		return nil, fmt.Errorf("failed to unmarshal install spec YAML from %s: %w", cfgFile, err)
-	}
-
-	return &installSpec, nil
 }
 
 // handleRunnerBinarySelection handles binary selection logic for runner scripts
@@ -246,7 +211,7 @@ generates a POSIX-compatible shell installer script.`,
 		log.Debugf("Using config file: %s", cfgFile)
 
 		// Load and parse InstallSpec
-		installSpec, err := loadInstallSpec(cfgFile)
+		installSpec, err := cmdutil.LoadInstallSpec(cfgFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -34,8 +34,6 @@ var (
 	// Input config file is handled by the global --config flag
 )
 
-const unnamedBinaryPlaceholder = "<unnamed>"
-
 // getAvailableBinaryNames extracts non-nil, non-empty binary names from the binaries list
 func getAvailableBinaryNames(binaries []spec.BinaryElement) []string {
 	var names []string
@@ -166,7 +164,7 @@ generates a POSIX-compatible shell installer script.`,
 			if genBinaryName == "" {
 				// Warning: multiple binaries found, using the first one
 				firstBinary := installSpec.Asset.Binaries[0]
-				binaryName := unnamedBinaryPlaceholder
+				binaryName := ""
 				if firstBinary.Name != nil && *firstBinary.Name != "" {
 					binaryName = *firstBinary.Name
 				}

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/binary-install/binstaller/internal/cmdutil"
 	"github.com/binary-install/binstaller/internal/shell" // Placeholder for script generator
 	"github.com/binary-install/binstaller/pkg/spec"
 	"github.com/spf13/cobra"
@@ -211,7 +210,7 @@ generates a POSIX-compatible shell installer script.`,
 		log.Debugf("Using config file: %s", cfgFile)
 
 		// Load and parse InstallSpec
-		installSpec, err := cmdutil.LoadInstallSpec(cfgFile)
+		installSpec, err := loadInstallSpec(cfgFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/gen_simple_test.go
+++ b/cmd/gen_simple_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenCommandMultiBinaryRunner(t *testing.T) {
+	// Simple test for multi-binary runner generation
+	tests := []struct {
+		name           string
+		yamlContent    string
+		binaryFlag     string
+		expectError    bool
+		expectBinaries []string
+	}{
+		{
+			name: "runner with multiple binaries - no flag",
+			yamlContent: `
+schema: v1
+name: multi-tool
+repo: example/multi-tool
+asset:
+  template: "${NAME}_${VERSION}_${OS}_${ARCH}.tar.gz"
+  binaries:
+    - name: tool1
+      path: bin/tool1
+    - name: tool2
+      path: bin/tool2
+`,
+			binaryFlag:     "",
+			expectError:    false,
+			expectBinaries: []string{"tool1"}, // Only first binary
+		},
+		{
+			name: "runner with multiple binaries - with flag",
+			yamlContent: `
+schema: v1
+name: multi-tool
+repo: example/multi-tool
+asset:
+  template: "${NAME}_${VERSION}_${OS}_${ARCH}.tar.gz"
+  binaries:
+    - name: tool1
+      path: bin/tool1
+    - name: tool2
+      path: bin/tool2
+`,
+			binaryFlag:     "tool2",
+			expectError:    false,
+			expectBinaries: []string{"tool2"}, // Only selected binary
+		},
+		{
+			name: "runner with invalid binary name",
+			yamlContent: `
+schema: v1
+name: multi-tool
+repo: example/multi-tool
+asset:
+  template: "${NAME}_${VERSION}_${OS}_${ARCH}.tar.gz"
+  binaries:
+    - name: tool1
+      path: bin/tool1
+    - name: tool2
+      path: bin/tool2
+`,
+			binaryFlag:  "nonexistent",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tmpDir := t.TempDir()
+			specFile := filepath.Join(tmpDir, "test.yml")
+			outputFile := filepath.Join(tmpDir, "output.sh")
+
+			// Write spec file
+			if err := os.WriteFile(specFile, []byte(tt.yamlContent), 0644); err != nil {
+				t.Fatalf("Failed to write spec file: %v", err)
+			}
+
+			// Set flags
+			configFile = specFile
+			genScriptType = "runner"
+			genBinaryName = tt.binaryFlag
+			genOutputFile = outputFile
+			genTargetVersion = ""
+
+			// Run command
+			err := GenCommand.RunE(GenCommand, []string{})
+
+			// Check error
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Read generated script
+			scriptContent, err := os.ReadFile(outputFile)
+			if err != nil {
+				t.Fatalf("Failed to read generated script: %v", err)
+			}
+
+			// Check expected binaries
+			scriptStr := string(scriptContent)
+			for _, binary := range tt.expectBinaries {
+				if !strings.Contains(scriptStr, "BINARY_NAME='"+binary+"'") {
+					t.Errorf("Expected binary %q not found in script", binary)
+				}
+			}
+		})
+	}
+}

--- a/cmd/gen_test.go
+++ b/cmd/gen_test.go
@@ -14,6 +14,7 @@ func TestGenCommandFlags(t *testing.T) {
 		wantType    string
 		wantOutput  string
 		wantVersion string
+		wantBinary  string
 		wantError   bool
 	}{
 		{
@@ -22,6 +23,7 @@ func TestGenCommandFlags(t *testing.T) {
 			wantType:    "installer",
 			wantOutput:  "-",
 			wantVersion: "",
+			wantBinary:  "",
 			wantError:   false,
 		},
 		{
@@ -30,6 +32,7 @@ func TestGenCommandFlags(t *testing.T) {
 			wantType:    "installer",
 			wantOutput:  "-",
 			wantVersion: "",
+			wantBinary:  "",
 			wantError:   false,
 		},
 		{
@@ -38,6 +41,7 @@ func TestGenCommandFlags(t *testing.T) {
 			wantType:    "runner",
 			wantOutput:  "-",
 			wantVersion: "",
+			wantBinary:  "",
 			wantError:   false,
 		},
 		{
@@ -46,6 +50,7 @@ func TestGenCommandFlags(t *testing.T) {
 			wantType:    "runner",
 			wantOutput:  "run.sh",
 			wantVersion: "",
+			wantBinary:  "",
 			wantError:   false,
 		},
 		{
@@ -54,6 +59,34 @@ func TestGenCommandFlags(t *testing.T) {
 			wantType:    "runner",
 			wantOutput:  "-",
 			wantVersion: "v1.2.3",
+			wantBinary:  "",
+			wantError:   false,
+		},
+		{
+			name:        "runner type with binary flag",
+			args:        []string{"--type", "runner", "--binary", "mytool"},
+			wantType:    "runner",
+			wantOutput:  "-",
+			wantVersion: "",
+			wantBinary:  "mytool",
+			wantError:   false,
+		},
+		{
+			name:        "installer type with binary flag (ignored)",
+			args:        []string{"--type", "installer", "--binary", "mytool"},
+			wantType:    "installer",
+			wantOutput:  "-",
+			wantVersion: "",
+			wantBinary:  "mytool",
+			wantError:   false,
+		},
+		{
+			name:        "runner with all flags",
+			args:        []string{"--type", "runner", "--binary", "helper", "-o", "run-helper.sh", "--target-version", "v2.0.0"},
+			wantType:    "runner",
+			wantOutput:  "run-helper.sh",
+			wantVersion: "v2.0.0",
+			wantBinary:  "helper",
 			wantError:   false,
 		},
 		{
@@ -62,6 +95,7 @@ func TestGenCommandFlags(t *testing.T) {
 			wantType:    "invalid",
 			wantOutput:  "-",
 			wantVersion: "",
+			wantBinary:  "",
 			wantError:   false, // Cobra accepts any string, validation happens in RunE
 		},
 	}
@@ -72,11 +106,13 @@ func TestGenCommandFlags(t *testing.T) {
 			genOutputFile = ""
 			genTargetVersion = ""
 			genScriptType = ""
+			genBinaryName = ""
 
 			cmd := &cobra.Command{Use: "gen"}
 			cmd.Flags().StringVarP(&genOutputFile, "output", "o", "-", "Output path for the generated script")
 			cmd.Flags().StringVar(&genTargetVersion, "target-version", "", "Generate script for specific version only")
 			cmd.Flags().StringVar(&genScriptType, "type", "installer", "Type of script to generate (installer, runner)")
+			cmd.Flags().StringVar(&genBinaryName, "binary", "", "For runner scripts with multiple binaries: specify which binary to run")
 
 			err := cmd.ParseFlags(tt.args)
 			if tt.wantError {
@@ -100,6 +136,10 @@ func TestGenCommandFlags(t *testing.T) {
 
 			if genTargetVersion != tt.wantVersion {
 				t.Errorf("genTargetVersion = %v, want %v", genTargetVersion, tt.wantVersion)
+			}
+
+			if genBinaryName != tt.wantBinary {
+				t.Errorf("genBinaryName = %v, want %v", genBinaryName, tt.wantBinary)
 			}
 		})
 	}
@@ -159,6 +199,7 @@ func TestGenCommandUsageExamples(t *testing.T) {
 	expectedExamples := []string{
 		"--type=runner",
 		"run.sh",
+		"--binary=mytool-helper",
 	}
 
 	for _, example := range expectedExamples {

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -1,4 +1,4 @@
-package cmdutil
+package cmd
 
 import (
 	"fmt"
@@ -10,8 +10,8 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-// LoadInstallSpec loads and parses the InstallSpec from the config file
-func LoadInstallSpec(cfgFile string) (*spec.InstallSpec, error) {
+// loadInstallSpec loads and parses the InstallSpec from the config file
+func loadInstallSpec(cfgFile string) (*spec.InstallSpec, error) {
 	// Read the InstallSpec YAML file
 	log.Debugf("Reading InstallSpec from: %s", cfgFile)
 	var yamlData []byte

--- a/internal/cmdutil/installspec.go
+++ b/internal/cmdutil/installspec.go
@@ -1,0 +1,45 @@
+package cmdutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/apex/log"
+	"github.com/binary-install/binstaller/pkg/spec"
+	"github.com/goccy/go-yaml"
+)
+
+// LoadInstallSpec loads and parses the InstallSpec from the config file
+func LoadInstallSpec(cfgFile string) (*spec.InstallSpec, error) {
+	// Read the InstallSpec YAML file
+	log.Debugf("Reading InstallSpec from: %s", cfgFile)
+	var yamlData []byte
+	var err error
+
+	if cfgFile == "-" {
+		log.Debug("Reading install spec from stdin")
+		yamlData, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			log.WithError(err).Error("Failed to read install spec from stdin")
+			return nil, fmt.Errorf("failed to read install spec from stdin: %w", err)
+		}
+	} else {
+		yamlData, err = os.ReadFile(cfgFile)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to read install spec file: %s", cfgFile)
+			return nil, fmt.Errorf("failed to read install spec file %s: %w", cfgFile, err)
+		}
+	}
+
+	// Unmarshal YAML into InstallSpec struct
+	log.Debug("Unmarshalling InstallSpec YAML")
+	var installSpec spec.InstallSpec
+	err = yaml.Unmarshal(yamlData, &installSpec)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to unmarshal install spec YAML from: %s", cfgFile)
+		return nil, fmt.Errorf("failed to unmarshal install spec YAML from %s: %w", cfgFile, err)
+	}
+
+	return &installSpec, nil
+}


### PR DESCRIPTION
## Summary

This PR adds support for selecting a specific binary when generating runner scripts for configurations with multiple binaries.

## Problem

When using `binst gen --type=runner` with an InstallSpec that contains multiple binaries, the runner script would attempt to execute all binaries sequentially. However, due to the use of `exec`, only the first binary would actually run, making it impossible to run other binaries.

## Solution

- Add a `--binary` flag to the `gen` command to specify which binary to run
- When multiple binaries exist and no flag is provided, show a warning and use the first binary
- Validate the specified binary name and show available options on error
- Filter the InstallSpec to only include the selected binary when generating runner scripts

## Usage

```bash
# Generate runner for specific binary when multiple exist
binst gen --type=runner --binary=tool2 -o run-tool2.sh

# Without flag, shows warning and uses first binary
binst gen --type=runner -o run.sh
# Warning: Multiple binaries found. Generating runner for the first binary 'tool1'.
# Use --binary flag to specify a different binary.
```

## Test plan

- [x] Added unit tests for flag parsing
- [x] Added integration tests for multi-binary runner generation
- [x] Tested error cases (invalid binary name)
- [x] All existing tests pass
- [x] Manual testing with example configurations

🤖 Generated with [Claude Code](https://claude.ai/code)