### PR TITLE
Fix schema help examples for platform extraction

### DIFF
--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -39,8 +39,8 @@ For filtering and processing, use yq or jq tools on the output.`,
   binst schema --format json | jq '."$defs".Platform'
 
   # Get list of supported platform os/arch combinations
-  binst schema | yq '.["$defs"].Platform.properties.os.anyOf[].const'
-  binst schema | yq '.["$defs"].Platform.properties.arch.anyOf[].const'`,
+  binst schema --format json | jq '.["$defs"].Platform.properties.os.anyOf[].const'
+  binst schema --format json | jq '.["$defs"].Platform.properties.arch.anyOf[].const'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format, _ := cmd.Flags().GetString("format")
 		return RunSchema(format, os.Stdout)

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -39,8 +39,8 @@ For filtering and processing, use yq or jq tools on the output.`,
   binst schema --format json | jq '."$defs".Platform'
 
   # Get list of supported platform os/arch combinations
-  binst schema | yq '."$defs".Platform.properties.os.enum'
-  binst schema | yq '."$defs".Platform.properties.arch.enum'`,
+  binst schema | yq '.["$defs"].Platform.properties.os.anyOf[].const'
+  binst schema | yq '.["$defs"].Platform.properties.arch.anyOf[].const'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format, _ := cmd.Flags().GetString("format")
 		return RunSchema(format, os.Stdout)


### PR DESCRIPTION
## Summary
- Fixed incorrect yq commands in schema help examples that were using non-existent `.enum` properties
- Updated commands to use correct `.anyOf[].const` paths for extracting OS and arch values
- Replaced yq examples with jq for better consistency and portability

## Test plan
- [x] Verified the old commands failed: `binst schema | yq '."$defs".Platform.properties.os.enum'` returned `null`
- [x] Verified the new commands work: `binst schema --format json | jq '.["$defs"].Platform.properties.os.anyOf[].const'` returns proper OS list
- [x] Tested both OS and arch extraction commands successfully

🤖 Generated with [Claude Code](https://claude.ai/code)