### PR TITLE
feat: implement Phase 1 version resolution for binst install command

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/binary-install/binstaller/pkg/httpclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Flags for install command
+	installBinDir string
+	installDryRun bool
+)
+
+// InstallCommand represents the install command
+var InstallCommand = &cobra.Command{
+	Use:   "install [VERSION]",
+	Short: "Install a binary directly from GitHub releases",
+	Long: `Install a binary directly from GitHub releases, achieving script-parity with the generated shell installers.
+
+This command provides a native Go implementation of the installation process, supporting version resolution, checksum verification, and cross-platform binary installation.`,
+	Example: `  # Install latest version
+  binst install
+
+  # Install specific version
+  binst install v1.2.3
+
+  # Install to custom directory
+  binst install --bin-dir=/usr/local/bin
+
+  # Dry run mode (verify URLs/versions without installing)
+  binst install --dry-run`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runInstall,
+}
+
+func init() {
+	InstallCommand.Flags().StringVarP(&installBinDir, "bin-dir", "b", "", "Installation directory")
+	InstallCommand.Flags().BoolVarP(&installDryRun, "dry-run", "n", false, "Dry run mode")
+}
+
+// GitHubRelease represents the GitHub API response for a release
+type GitHubRelease struct {
+	TagName string `json:"tag_name"`
+	Name    string `json:"name"`
+}
+
+// gitHubAPIBaseURL is the base URL for GitHub API calls (overridable for testing)
+var gitHubAPIBaseURL = "https://api.github.com"
+
+// resolveVersion resolves a version string to an actual GitHub release tag
+func resolveVersion(ctx context.Context, repo, version string) (string, error) {
+	if version != "" && version != "latest" {
+		// User provided explicit version, use as-is
+		return version, nil
+	}
+
+	// Resolve "latest" to actual tag using GitHub API
+	log.Info("checking GitHub for latest tag")
+
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", gitHubAPIBaseURL, repo)
+
+	client := httpclient.NewGitHubClient()
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var release GitHubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if release.TagName == "" {
+		return "", fmt.Errorf("no tag_name found in GitHub response")
+	}
+
+	return release.TagName, nil
+}
+
+func runInstall(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	// 1. Resolve config file path
+	cfgPath, err := resolveConfigFile(configFile)
+	if err != nil {
+		return err
+	}
+
+	// 2. Load config
+	spec, err := loadInstallSpec(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	// Get repo from spec
+	if spec.Repo == nil || *spec.Repo == "" {
+		return fmt.Errorf("GitHub repo not specified in config")
+	}
+	repo := *spec.Repo
+
+	// 3. Get version from args (positional VERSION argument)
+	version := ""
+	if len(args) > 0 {
+		version = args[0]
+	}
+
+	// 4. Resolve version (latest if not specified)
+	resolvedVersion, err := resolveVersion(ctx, repo, version)
+	if err != nil {
+		return fmt.Errorf("failed to resolve version: %w", err)
+	}
+
+	// Strip leading 'v' if present for the version number
+	versionNumber := strings.TrimPrefix(resolvedVersion, "v")
+
+	log.Infof("Resolved version: %s (tag: %s)", versionNumber, resolvedVersion)
+
+	if installDryRun {
+		log.Info("Dry run mode - skipping actual installation")
+		// TODO: In future phases, validate asset URLs exist
+		return nil
+	}
+
+	// TODO: Phase 2+ implementation
+	// - Use pkg/asset.FilenameGenerator for asset resolution
+	// - Use pkg/httpclient for downloading files
+	// - Use pkg/checksums for verification
+	// - Implement extraction and installation
+
+	return fmt.Errorf("installation not yet implemented (Phase 1 complete)")
+}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		repo            string
+		inputVersion    string
+		serverResponse  interface{}
+		serverStatus    int
+		expectedVersion string
+		expectedError   bool
+		setupEnv        func()
+		cleanupEnv      func()
+	}{
+		{
+			name:            "explicit version returns as-is",
+			repo:            "owner/repo",
+			inputVersion:    "v1.2.3",
+			expectedVersion: "v1.2.3",
+			expectedError:   false,
+		},
+		{
+			name:            "explicit version without v prefix",
+			repo:            "owner/repo",
+			inputVersion:    "1.2.3",
+			expectedVersion: "1.2.3",
+			expectedError:   false,
+		},
+		{
+			name:         "latest resolves to actual tag",
+			repo:         "owner/repo",
+			inputVersion: "latest",
+			serverResponse: GitHubRelease{
+				TagName: "v2.0.0",
+				Name:    "Release v2.0.0",
+			},
+			serverStatus:    http.StatusOK,
+			expectedVersion: "v2.0.0",
+			expectedError:   false,
+		},
+		{
+			name:         "empty version resolves to latest",
+			repo:         "owner/repo",
+			inputVersion: "",
+			serverResponse: GitHubRelease{
+				TagName: "v3.0.0",
+				Name:    "Release v3.0.0",
+			},
+			serverStatus:    http.StatusOK,
+			expectedVersion: "v3.0.0",
+			expectedError:   false,
+		},
+		{
+			name:         "handles GitHub API error",
+			repo:         "owner/repo",
+			inputVersion: "latest",
+			serverResponse: map[string]string{
+				"message": "Not Found",
+			},
+			serverStatus:  http.StatusNotFound,
+			expectedError: true,
+		},
+		{
+			name:         "handles empty tag_name",
+			repo:         "owner/repo",
+			inputVersion: "latest",
+			serverResponse: GitHubRelease{
+				TagName: "",
+				Name:    "Release without tag",
+			},
+			serverStatus:  http.StatusOK,
+			expectedError: true,
+		},
+		{
+			name:         "respects GITHUB_TOKEN",
+			repo:         "owner/repo",
+			inputVersion: "latest",
+			serverResponse: GitHubRelease{
+				TagName: "v4.0.0",
+				Name:    "Release v4.0.0",
+			},
+			serverStatus:    http.StatusOK,
+			expectedVersion: "v4.0.0",
+			expectedError:   false,
+			setupEnv: func() {
+				os.Setenv("GITHUB_TOKEN", "test-token")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("GITHUB_TOKEN")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setupEnv != nil {
+				tt.setupEnv()
+			}
+			if tt.cleanupEnv != nil {
+				defer tt.cleanupEnv()
+			}
+
+			// Create test server if we need to test API calls
+			if tt.inputVersion == "" || tt.inputVersion == "latest" {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Verify request path
+					expectedPath := "/repos/" + tt.repo + "/releases/latest"
+					if r.URL.Path != expectedPath {
+						t.Errorf("unexpected path: got %s, want %s", r.URL.Path, expectedPath)
+					}
+
+					// Verify GitHub token handling
+					// Note: httpclient only adds token for github.com URLs
+					// Since this is a test server, we can't verify the token here
+
+					// Send response
+					w.WriteHeader(tt.serverStatus)
+					if tt.serverResponse != nil {
+						json.NewEncoder(w).Encode(tt.serverResponse)
+					}
+				}))
+				defer server.Close()
+
+				// Override GitHub API URL for testing
+				oldURL := gitHubAPIBaseURL
+				gitHubAPIBaseURL = server.URL
+				defer func() { gitHubAPIBaseURL = oldURL }()
+			}
+
+			ctx := context.Background()
+			version, err := resolveVersion(ctx, tt.repo, tt.inputVersion)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if version != tt.expectedVersion {
+					t.Errorf("unexpected version: got %s, want %s", version, tt.expectedVersion)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallCommandFlags(t *testing.T) {
+	// Reset command for testing
+	cmd := InstallCommand
+
+	// Test that flags are properly defined
+	binDirFlag := cmd.Flags().Lookup("bin-dir")
+	if binDirFlag == nil {
+		t.Fatal("bin-dir flag not found")
+	}
+	if binDirFlag.Shorthand != "b" {
+		t.Errorf("bin-dir shorthand: got %s, want b", binDirFlag.Shorthand)
+	}
+
+	dryRunFlag := cmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Fatal("dry-run flag not found")
+	}
+	if dryRunFlag.Shorthand != "n" {
+		t.Errorf("dry-run shorthand: got %s, want n", dryRunFlag.Shorthand)
+	}
+}
+
+func TestInstallCommandArgs(t *testing.T) {
+	cmd := InstallCommand
+
+	// Test that command accepts 0 or 1 argument
+	if err := cmd.Args(cmd, []string{}); err != nil {
+		t.Errorf("command should accept 0 args: %v", err)
+	}
+
+	if err := cmd.Args(cmd, []string{"v1.0.0"}); err != nil {
+		t.Errorf("command should accept 1 arg: %v", err)
+	}
+
+	if err := cmd.Args(cmd, []string{"v1.0.0", "extra"}); err == nil {
+		t.Error("command should reject 2 args")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,7 @@ func init() {
 	CheckCommand.GroupID = "workflow"
 	EmbedChecksumsCommand.GroupID = "workflow"
 	GenCommand.GroupID = "workflow"
+	InstallCommand.GroupID = "workflow"
 	HelpfulCommand.GroupID = "utility"
 	SchemaCommand.GroupID = "utility"
 
@@ -112,6 +113,7 @@ func init() {
 	RootCmd.AddCommand(CheckCommand)          // Step 2: Validate config
 	RootCmd.AddCommand(EmbedChecksumsCommand) // Step 3: Embed checksums (optional)
 	RootCmd.AddCommand(GenCommand)            // Step 4: Generate installer
+	RootCmd.AddCommand(InstallCommand)        // Alternative: Install binary directly
 	RootCmd.AddCommand(HelpfulCommand)        // Utility: Comprehensive help for LLMs
 	RootCmd.AddCommand(SchemaCommand)         // Utility: Display configuration schema
 }


### PR DESCRIPTION
Closes #189

## Summary

Implements Phase 1 of the `binst install` command as outlined in the design document.

## Changes

- Add new `install` command with basic CLI skeleton
- Implement version resolution logic to resolve 'latest' to actual GitHub release
- Support positional VERSION argument
- Use existing `pkg/httpclient` for GitHub API calls with GITHUB_TOKEN support
- Add comprehensive unit tests for version resolution

## Testing

- All unit tests pass
- Linting passes
- Manual testing with sample configs works correctly

Generated with [Claude Code](https://claude.ai/code)