### PR TITLE
fix: preserve arguments with spaces in runner scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ test-target-version: binst ## Test target version functionality
 test-runner-mode: binst ## Test runner mode functionality
 	@echo "Testing runner mode functionality..."
 	@./test/runner_mode.sh
+	@echo "Testing runner argument handling with spaces..."
+	@./test/runner_args_spaces.sh
 
 # End-to-end tests for binst install command
 test-e2e-parity: binst ## Test parity between binst install and generated scripts

--- a/internal/shell/script_test.go
+++ b/internal/shell/script_test.go
@@ -518,7 +518,7 @@ func TestGenerateRunner(t *testing.T) {
 			targetVersion: "",
 			wantSubstrings: []string{
 				`# This script runs test-tool directly without installing`,
-				`exec "${BINARY_PATH}" $TOOL_ARGS`,
+				`exec "${BINARY_PATH}" "$@"`,
 				`cleanup() {`,
 				`trap cleanup EXIT HUP INT TERM`,
 				`chmod +x "${BINARY_PATH}"`,
@@ -543,7 +543,7 @@ func TestGenerateRunner(t *testing.T) {
 			wantSubstrings: []string{
 				`# This script runs test-tool directly without installing`,
 				`TAG="v1.2.3"`,
-				`exec "${BINARY_PATH}" $TOOL_ARGS`,
+				`exec "${BINARY_PATH}" "$@"`,
 				`chmod +x "${BINARY_PATH}"`,
 			},
 			wantNotContain: []string{
@@ -639,7 +639,7 @@ func TestGenerateWithScriptType(t *testing.T) {
 			scriptType: "runner",
 			wantError:  false,
 			checkFunc: func(script string) bool {
-				return strings.Contains(script, `exec "${BINARY_PATH}" $TOOL_ARGS`) &&
+				return strings.Contains(script, `exec "${BINARY_PATH}" "$@"`) &&
 					strings.Contains(script, `chmod +x "${BINARY_PATH}"`)
 			},
 		},

--- a/test/runner_args_spaces.sh
+++ b/test/runner_args_spaces.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Test that runner scripts correctly handle arguments with spaces
+# This tests the fix for issue #212
+
+set -e
+
+# Setup
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BINST="${PROJECT_ROOT}/binst"
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf -- "$TEMP_DIR"' EXIT
+
+cd "$PROJECT_ROOT"
+
+echo "=== Testing runner script with arguments containing spaces ==="
+echo ""
+
+# Generate jq runner script
+echo "Generating jq runner script..."
+"$BINST" gen --config testdata/jq.binstaller.yml --type runner -o "$TEMP_DIR/jq-runner.sh"
+chmod +x "$TEMP_DIR/jq-runner.sh"
+
+# Test 1: Simple jq filter with spaces in string literal
+echo "Test 1: Filter with spaces in string literal"
+result=$(echo '{"name": "John Doe", "age": 30}' | "$TEMP_DIR/jq-runner.sh" -- '.name == "John Doe"')
+if [ "$result" = "true" ]; then
+    echo "  ✓ Passed: String with spaces preserved"
+else
+    echo "  ✗ Failed: Expected 'true', got '$result'"
+    exit 1
+fi
+
+# Test 2: jq with --arg containing spaces
+echo "Test 2: --arg parameter with spaces"
+result=$(echo '{"greeting": "Hello World"}' | "$TEMP_DIR/jq-runner.sh" -- --arg msg 'Hello World' '.greeting == $msg')
+if [ "$result" = "true" ]; then
+    echo "  ✓ Passed: --arg with spaces preserved"
+else
+    echo "  ✗ Failed: Expected 'true', got '$result'"
+    exit 1
+fi
+
+# Test 3: Complex jq expression with spaces and pipes
+echo "Test 3: Complex expression with pipes and spaces"
+result=$(echo '[{"name": "Alice Smith"}, {"name": "Bob Jones"}]' | \
+    "$TEMP_DIR/jq-runner.sh" -- '.[] | select(.name | contains("Smith"))' | \
+    jq -r '.name')
+if [ "$result" = "Alice Smith" ]; then
+    echo "  ✓ Passed: Complex expression preserved"
+else
+    echo "  ✗ Failed: Expected 'Alice Smith', got '$result'"
+    exit 1
+fi
+
+# Test 4: Template-like expression (simulating github-comment case)
+echo "Test 4: Template-like expression with special characters"
+result=$(echo '{"content": "test data"}' | \
+    "$TEMP_DIR/jq-runner.sh" -- --arg template '{{ .Vars.content | AvoidHTMLEscape }}' \
+    '{template: $template}' | jq -r '.template')
+if [ "$result" = "{{ .Vars.content | AvoidHTMLEscape }}" ]; then
+    echo "  ✓ Passed: Template expression preserved"
+else
+    echo "  ✗ Failed: Template expression was mangled"
+    echo "    Expected: '{{ .Vars.content | AvoidHTMLEscape }}'"
+    echo "    Got: '$result'"
+    exit 1
+fi
+
+# Test 5: Multiple arguments with varying content
+echo "Test 5: Multiple mixed arguments"
+result=$(echo '{}' | \
+    "$TEMP_DIR/jq-runner.sh" -- \
+    --arg a 'first arg' \
+    --arg b 'second arg with more spaces' \
+    --arg c 'third' \
+    '{a: $a, b: $b, c: $c}' | jq -r '.b')
+if [ "$result" = "second arg with more spaces" ]; then
+    echo "  ✓ Passed: Multiple arguments preserved"
+else
+    echo "  ✗ Failed: Multiple arguments were not preserved correctly"
+    echo "    Expected: 'second arg with more spaces'"
+    echo "    Got: '$result'"
+    exit 1
+fi
+
+# Test 6: Arguments with special shell characters
+echo "Test 6: Arguments with special shell characters"
+result=$(echo '{}' | \
+    "$TEMP_DIR/jq-runner.sh" -- \
+    --arg special '$HOME/*.txt' \
+    '{special: $special}' | jq -r '.special')
+if [ "$result" = '$HOME/*.txt' ]; then
+    echo "  ✓ Passed: Special characters not expanded"
+else
+    echo "  ✗ Failed: Special characters were incorrectly expanded"
+    echo "    Expected: '\$HOME/*.txt'"
+    echo "    Got: '$result'"
+    exit 1
+fi
+
+# Test 7: Empty string and whitespace-only arguments
+echo "Test 7: Empty and whitespace-only arguments"
+result=$(echo '{}' | \
+    "$TEMP_DIR/jq-runner.sh" -- \
+    --arg empty '' \
+    --arg spaces '   ' \
+    '{empty: $empty, spaces: $spaces, empty_len: ($empty | length), spaces_len: ($spaces | length)}' | \
+    jq -r '.spaces_len')
+if [ "$result" = "3" ]; then
+    echo "  ✓ Passed: Whitespace preserved correctly"
+else
+    echo "  ✗ Failed: Whitespace not preserved"
+    echo "    Expected length: 3"
+    echo "    Got length: '$result'"
+    exit 1
+fi
+
+echo ""
+echo "=== All tests passed! ==="
+echo "Runner scripts correctly preserve arguments with spaces."

--- a/testdata/ast-grep.install.sh
+++ b/testdata/ast-grep.install.sh
@@ -559,5 +559,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/bat.install.sh
+++ b/testdata/bat.install.sh
@@ -551,5 +551,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/bump.install.sh
+++ b/testdata/bump.install.sh
@@ -558,5 +558,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/cargo-deny.install.sh
+++ b/testdata/cargo-deny.install.sh
@@ -555,5 +555,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/cnappgoat.install.sh
+++ b/testdata/cnappgoat.install.sh
@@ -558,5 +558,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/dockle.install.sh
+++ b/testdata/dockle.install.sh
@@ -579,5 +579,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/dotter.install.sh
+++ b/testdata/dotter.install.sh
@@ -555,5 +555,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/dua-cli.install.sh
+++ b/testdata/dua-cli.install.sh
@@ -570,5 +570,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/fzf.install.sh
+++ b/testdata/fzf.install.sh
@@ -539,5 +539,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/gh-setup.install.sh
+++ b/testdata/gh-setup.install.sh
@@ -539,5 +539,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/gh.install.sh
+++ b/testdata/gh.install.sh
@@ -543,5 +543,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/ghq.install.sh
+++ b/testdata/ghq.install.sh
@@ -535,5 +535,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/git-bump.install.sh
+++ b/testdata/git-bump.install.sh
@@ -550,5 +550,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/golangci-lint.install.sh
+++ b/testdata/golangci-lint.install.sh
@@ -539,5 +539,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/goreleaser.install.sh
+++ b/testdata/goreleaser.install.sh
@@ -554,5 +554,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/gorss.install.sh
+++ b/testdata/gorss.install.sh
@@ -550,5 +550,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/gum.install.sh
+++ b/testdata/gum.install.sh
@@ -619,5 +619,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/hugo.install.sh
+++ b/testdata/hugo.install.sh
@@ -543,5 +543,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/jq.install.sh
+++ b/testdata/jq.install.sh
@@ -543,5 +543,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/kauthproxy.install.sh
+++ b/testdata/kauthproxy.install.sh
@@ -568,5 +568,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/micro.install.sh
+++ b/testdata/micro.install.sh
@@ -563,5 +563,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/reviewdog-nightly.install.sh
+++ b/testdata/reviewdog-nightly.install.sh
@@ -551,5 +551,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/reviewdog.install.sh
+++ b/testdata/reviewdog.install.sh
@@ -550,5 +550,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/ripgrep.install.sh
+++ b/testdata/ripgrep.install.sh
@@ -567,5 +567,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/rush.install.sh
+++ b/testdata/rush.install.sh
@@ -532,5 +532,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/shellcheck.install.sh
+++ b/testdata/shellcheck.install.sh
@@ -547,5 +547,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/sigspy.install.sh
+++ b/testdata/sigspy.install.sh
@@ -554,5 +554,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/slsa-verifier.install.sh
+++ b/testdata/slsa-verifier.install.sh
@@ -535,5 +535,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/tagpr.install.sh
+++ b/testdata/tagpr.install.sh
@@ -543,5 +543,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/treesitter.install.sh
+++ b/testdata/treesitter.install.sh
@@ -543,5 +543,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/ubi.install.sh
+++ b/testdata/ubi.install.sh
@@ -559,5 +559,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/xh.install.sh
+++ b/testdata/xh.install.sh
@@ -570,5 +570,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute

--- a/testdata/xo.install.sh
+++ b/testdata/xo.install.sh
@@ -539,5 +539,4 @@ uname_arch_check "$ARCH"
 tag_to_version
 
 resolve_asset_filename
-
 execute


### PR DESCRIPTION
## Summary

Fixes #212 - Runner scripts now correctly preserve arguments containing spaces.

## Problem

The binstaller-generated runner scripts were incorrectly splitting arguments that contained spaces due to unquoted variable expansion. This broke tools that needed complex arguments like Go templates, JSON queries, or any string with spaces.

For example, this would fail:
```bash
./github-comment-runner.sh -- post --template '{{ .Vars.content | AvoidHTMLEscape }}'
```

The shell would split the template into separate arguments, causing parse errors.

## Solution  

The fix tracks how many wrapper arguments were consumed during parsing and properly preserves the remaining arguments:

1. **Track consumed arguments**: Added `PARSE_CONSUMED` counter to track wrapper script arguments
2. **Shift before exec**: Shift the consumed arguments before passing remainder to the binary
3. **Preserve boundaries**: Use `"$@"` instead of unquoted `$TOOL_ARGS` to maintain argument boundaries

## Test Plan

Added comprehensive test script `test/runner_args_spaces.sh` that verifies:
- [x] String literals with spaces
- [x] `--arg` parameters with spaces
- [x] Complex expressions with pipes
- [x] Template expressions (github-comment case)
- [x] Multiple mixed arguments
- [x] Special shell characters (not expanded)
- [x] Empty and whitespace-only arguments

All existing tests pass with `make ci`.

🤖 Generated with [Claude Code](https://claude.ai/code)