### PR TITLE
fix: allow ${ASSET_FILENAME} in checksum templates with calculate mode

### DIFF
--- a/pkg/checksums/checksums.go
+++ b/pkg/checksums/checksums.go
@@ -61,10 +61,10 @@ func (e *Embedder) Embed() error {
 	}
 
 	// Validate checksum template for embed-checksums command
-	// Note: ${ASSET_FILENAME} is supported in runtime verification but not in embed-checksums
-	// because it would require looping through all supported OS/arch combinations,
-	// which is equivalent to using 'calculate' mode.
-	if e.Mode != "" && e.Spec.Checksums.Template != nil && strings.Contains(spec.StringValue(e.Spec.Checksums.Template), "${ASSET_FILENAME}") {
+	// Note: ${ASSET_FILENAME} is supported in runtime verification and in calculate mode
+	// but not in download or checksum-file modes because those modes work with a single
+	// checksum file that doesn't have per-asset filenames
+	if e.Mode != "" && e.Mode != EmbedModeCalculate && e.Spec.Checksums.Template != nil && strings.Contains(spec.StringValue(e.Spec.Checksums.Template), "${ASSET_FILENAME}") {
 		return fmt.Errorf("${ASSET_FILENAME} is not supported in checksum templates for embed-checksums. Use 'binst embed-checksums --mode calculate' instead to generate checksums for all platforms")
 	}
 

--- a/pkg/checksums/interpolate_test.go
+++ b/pkg/checksums/interpolate_test.go
@@ -210,6 +210,31 @@ func TestEmbedAssetFilenameValidation(t *testing.T) {
 	}
 }
 
+func TestEmbedAssetFilenameCalculateMode(t *testing.T) {
+	spec := &spec.InstallSpec{
+		Name: spec.StringPtr("mytool"),
+		Repo: spec.StringPtr("owner/mytool"),
+		Checksums: &spec.ChecksumConfig{
+			Template: spec.StringPtr("${ASSET_FILENAME}.sha256"),
+		},
+	}
+
+	// Test that calculate mode does not error with ASSET_FILENAME
+	e := &Embedder{
+		Spec:    spec,
+		Version: "v1.2.3",
+		Mode:    EmbedModeCalculate,
+	}
+
+	// This test doesn't actually perform the full embed (which would require network access)
+	// but validates that the error checking doesn't trigger for calculate mode
+	err := e.Embed()
+	// We expect an error from not having release assets, NOT from ASSET_FILENAME validation
+	if err != nil && strings.Contains(err.Error(), "${ASSET_FILENAME} is not supported") {
+		t.Errorf("calculate mode should allow ASSET_FILENAME in templates, got error: %v", err)
+	}
+}
+
 func TestGenerateAssetFilename_Interpolation(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Fixes #225

Previously, embed-checksums with --mode calculate incorrectly rejected checksum templates containing ${ASSET_FILENAME}, even though calculate mode is designed to handle per-asset checksums.

This fix updates the validation logic to exclude EmbedModeCalculate from the ASSET_FILENAME restriction, allowing calculate mode to work properly with asset-specific checksum templates.

Generated with [Claude Code](https://claude.ai/code)